### PR TITLE
Improve media path normalization and fix gallery seeds

### DIFF
--- a/seed_database.py
+++ b/seed_database.py
@@ -49,12 +49,12 @@ def seed_gallery():
             return
 
         images = [
-            {"url": "static/img/gallery/gallery-1.jpg", "caption": "الشيخ مصطفى الطحان خلال مؤتمر دولي"},
-            {"url": "static/img/gallery/gallery-2.jpg", "caption": "حفل توقيع كتاب من تأليف الشيخ"},
-            {"url": "static/img/gallery/gallery-3.jpg", "caption": "الشيخ مصطفى الطحان في محاضرة ثقافية"},
-            {"url": "static/img/gallery/gallery-4.jpg", "caption": "مشاركة الشيخ في ندوة فكرية"},
-            {"url": "static/img/gallery/gallery-5.jpg", "caption": "لقاء مع طلاب العلم"},
-            {"url": "static/img/gallery/gallery-6.jpg", "caption": "جلسة نقاش مع علماء معاصرين"}
+            {"url": "static/img/gallery/gallery1.jpg", "caption": "الشيخ مصطفى الطحان خلال مؤتمر دولي"},
+            {"url": "static/img/gallery/gallery2.jpg", "caption": "حفل توقيع كتاب من تأليف الشيخ"},
+            {"url": "static/img/gallery/gallery3.jpg", "caption": "الشيخ مصطفى الطحان في محاضرة ثقافية"},
+            {"url": "static/img/gallery/gallery4.jpg", "caption": "مشاركة الشيخ في ندوة فكرية"},
+            {"url": "static/img/gallery/gallery5.jpg", "caption": "لقاء مع طلاب العلم"},
+            {"url": "static/img/gallery/gallery6.jpg", "caption": "جلسة نقاش مع علماء معاصرين"}
         ]
 
         for image_data in images:


### PR DESCRIPTION
## Summary
- harden the media URL normalizer to decode wrapped values, validate local files, and gracefully fall back to defaults
- update gallery seed data to reference the bundled gallery thumbnails that actually exist

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68d218cda834832ea79cb6fdb2ffeecd